### PR TITLE
grakn-node --> grakn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grakn-node",
+  "name": "grakn",
   "version": "0.0.4",
   "graknVersion": "0.16.0",
   "description": "Grakn Node.js Client",


### PR DESCRIPTION
`npm info grakn` returns nothing currently.

Many multi-platform SDKs use the convention of `<name>-<platform>` on Github, but the convention for Node projects is usually to leave out the `-node` in the NPM package if possible, I think mostly so it doesn't have to be included in `require` calls everywhere :)