### PR TITLE
Updgraded driver for GRAKN 0.17.x

### DIFF
--- a/src/GraknGraph.js
+++ b/src/GraknGraph.js
@@ -2,7 +2,7 @@ const request = require('request-promise-native');
 
 const DEFAULT_URI = 'http://localhost:4567';
 const DEFAULT_KEYSPACE = 'grakn';
-const EXECUTE_WEBPATH = '/graph/graql/execute';
+const EXECUTE_WEBPATH = '/kb/graql/execute';
 
 let uri, keyspace;
 

--- a/tests/graph.test.js
+++ b/tests/graph.test.js
@@ -43,7 +43,7 @@ describe('Test query execution', () => {
 
     test('Executing a query sends request to expected URI', () => {
         graph.execute(query);
-        expect(currentRequestOptions.uri).toBe('http://test-url.com/graph/graql/execute');
+        expect(currentRequestOptions.uri).toBe('http://test-url.com/kb/graql/execute');
     });
 
     test('Executing a query sends expected headers', () => {


### PR DESCRIPTION
The driver was not working as the endpoint has changed `graph/graql/execute` became `kb/graql/execute`

The driver now works and passed unit tests (I had to modify it too). 